### PR TITLE
Change the design of front end

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -58,3 +58,24 @@
     box-shadow: 0 0 5px #2b88d8;
   }
 }
+
+/* Material-UI specific styles */
+.MuiContainer-root {
+  padding: 2rem;
+}
+
+.MuiTypography-root {
+  margin-bottom: 1rem;
+}
+
+.MuiButton-root {
+  margin-top: 1rem;
+}
+
+.MuiBox-root {
+  margin-bottom: 1rem;
+}
+
+.MuiCircularProgress-root {
+  margin-left: 0.5rem;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import AppRoutes from "./routes";
 import "./App.css";
 import { useMsal } from "@azure/msal-react";
-import { Col, Container, Row } from "react-bootstrap";
+import { Container, Grid, Box } from "@mui/material";
 
 const App: React.FC = () => {
   const { accounts } = useMsal();
@@ -11,21 +11,21 @@ const App: React.FC = () => {
   return (
     <>
       {!isAuthenticated && (
-        <div className="auth-landing-page">
-          <div className="auth-container">
-            <div className="button-container">
+        <Box className="auth-landing-page">
+          <Box className="auth-container">
+            <Box className="button-container">
               <AppRoutes />
-            </div>
-          </div>
-        </div>
+            </Box>
+          </Box>
+        </Box>
       )}
       {isAuthenticated && (
         <Container>
-          <Row>
-            <Col xs={12} id="page-content-wrapper">
+          <Grid container>
+            <Grid item xs={12} id="page-content-wrapper">
               <AppRoutes />
-            </Col>
-          </Row>
+            </Grid>
+          </Grid>
         </Container>
       )}
     </>

--- a/frontend/src/components/AddAccount.tsx
+++ b/frontend/src/components/AddAccount.tsx
@@ -5,6 +5,7 @@ import { InteractionRequiredAuthError } from "@azure/msal-browser";
 import { LOCAL_STORAGE_KEYS } from "../utils/LocalStorageConstant";
 import { useNavigate } from "react-router-dom";
 import { AppConst } from "../utils/AppConstant";
+import { Container, Typography, CircularProgress } from "@mui/material";
 
 /**
  * AddAccount component
@@ -58,9 +59,16 @@ const AddAccount: React.FC = () => {
   };
 
   return (
-    <div className="container center-screen">
-      {inProgress && <h3>Adding Outlook Account & Fetching Emails...</h3>}
-    </div>
+    <Container className="center-screen">
+      {inProgress && (
+        <>
+          <Typography variant="h5" component="h3">
+            Adding Outlook Account & Fetching Emails...
+          </Typography>
+          <CircularProgress />
+        </>
+      )}
+    </Container>
   );
 };
 

--- a/frontend/src/components/EmailPage.tsx
+++ b/frontend/src/components/EmailPage.tsx
@@ -5,8 +5,18 @@ import {
   Modal,
   Table,
   Alert,
-  Spinner,
-} from "react-bootstrap";
+  CircularProgress,
+  Box,
+  Typography,
+  IconButton,
+  Tooltip,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Paper,
+} from "@mui/material";
 import { CSSTransition } from 'react-transition-group';
 import AxiosWrapper from "../utils/AxiosWrapper";
 import { useMsal } from "@azure/msal-react";
@@ -169,103 +179,117 @@ const EmailPage: React.FC = () => {
 
   return (
     <Container className="main-content">
-      <div className="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-        <h1 className="h2">Email Data Synchronization</h1>
-        <p className="lead">
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={3} borderBottom={1} pb={2}>
+        <Typography variant="h4">Email Data Synchronization</Typography>
+        <Typography variant="subtitle1">
           <small>Sync-Status: {syncStatus}</small>
-        </p>
-        <p className="lead">
+        </Typography>
+        <Typography variant="subtitle1">
           <small>Connection Status: {connectionStatus}</small>
-        </p>
+        </Typography>
         {isRetrying && (
-          <p className="lead">
+          <Typography variant="subtitle1">
             <small>Retrying to connect... (Attempt {retryCount})</small>
-            <Spinner animation="border" size="sm" />
-          </p>
+            <CircularProgress size={20} />
+          </Typography>
         )}
         {connectionStatus !== "Connected" && !isRetrying && (
-          <Button onClick={attemptReconnect} variant="primary">
+          <Button onClick={attemptReconnect} variant="contained" color="primary">
             Retry Connection
           </Button>
         )}
-      </div>
+      </Box>
       {connectionStatus !== "Connected" && (
-        <Alert variant="danger">Connection issue: {connectionStatus}</Alert>
+        <Alert severity="error">Connection issue: {connectionStatus}</Alert>
       )}
-      <Table bordered striped hover responsive>
-        <thead className="thead-light">
-          <tr>
-            <th>Subject</th>
-            <th>Sender name</th>
-            <th>Status</th>
-            <th>Flag</th>
-          </tr>
-        </thead>
-        <tbody>
-          {emails.map((email) => (
-            <CSSTransition key={email.id} timeout={500} classNames="email-new">
-              <tr
-                key={email.id}
-                onClick={() => handleRowClick(email)}
-                className="cursor-pointer"
-              >
-                <td>
-                  <strong>{email.subject}</strong>
-                </td>
-                <td>{email.sender.emailAddress.name}</td>
-                <td>
-                  {email.isRead ? (
-                    <FontAwesomeIcon icon={faEnvelopeOpen} title="Read" className="email-icon-glow-read" />
-                  ) : (
-                    <FontAwesomeIcon icon={faEnvelope} title="Unread" className="email-icon-glow-read" />
-                  )}
-                  {email.isMoved && (
-                    <FontAwesomeIcon
-                      icon={faFolder}
-                      title="Moved"
-                      className="ml-2"
-                    />
-                  )}
-                </td>
-                <td>
-                  {email.isFlagged && (
-                    <FontAwesomeIcon icon={faFlag} title="Flagged" className="email-icon-glow-flag" />
-                  )}
-                  {email.isDeleted && (
-                    <FontAwesomeIcon icon={faTrash} title="Deleted" />
-                  )}
-                </td>
-              </tr>
-            </CSSTransition>
-          ))}
-        </tbody>
-      </Table>
-      <Modal show={showModal} onHide={handleCloseModal} size="lg">
-        <Modal.Header closeButton>
-          <Modal.Title>{selectedEmail?.subject}</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <p>
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Subject</TableCell>
+              <TableCell>Sender name</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell>Flag</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {emails.map((email) => (
+              <CSSTransition key={email.id} timeout={500} classNames="email-new">
+                <TableRow
+                  key={email.id}
+                  onClick={() => handleRowClick(email)}
+                  className="cursor-pointer"
+                >
+                  <TableCell>
+                    <strong>{email.subject}</strong>
+                  </TableCell>
+                  <TableCell>{email.sender.emailAddress.name}</TableCell>
+                  <TableCell>
+                    {email.isRead ? (
+                      <Tooltip title="Read">
+                        <IconButton>
+                          <FontAwesomeIcon icon={faEnvelopeOpen} className="email-icon-glow-read" />
+                        </IconButton>
+                      </Tooltip>
+                    ) : (
+                      <Tooltip title="Unread">
+                        <IconButton>
+                          <FontAwesomeIcon icon={faEnvelope} className="email-icon-glow-read" />
+                        </IconButton>
+                      </Tooltip>
+                    )}
+                    {email.isMoved && (
+                      <Tooltip title="Moved">
+                        <IconButton>
+                          <FontAwesomeIcon icon={faFolder} className="ml-2" />
+                        </IconButton>
+                      </Tooltip>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {email.isFlagged && (
+                      <Tooltip title="Flagged">
+                        <IconButton>
+                          <FontAwesomeIcon icon={faFlag} className="email-icon-glow-flag" />
+                        </IconButton>
+                      </Tooltip>
+                    )}
+                    {email.isDeleted && (
+                      <Tooltip title="Deleted">
+                        <IconButton>
+                          <FontAwesomeIcon icon={faTrash} />
+                        </IconButton>
+                      </Tooltip>
+                    )}
+                  </TableCell>
+                </TableRow>
+              </CSSTransition>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <Modal open={showModal} onClose={handleCloseModal}>
+        <Box>
+          <Typography variant="h6">{selectedEmail?.subject}</Typography>
+          <Typography>
             <strong>From:</strong> {selectedEmail?.sender.emailAddress.name}
-          </p>
-          <p>
+          </Typography>
+          <Typography>
             <strong>Email:</strong> {selectedEmail?.sender.emailAddress.address}
-          </p>
-          <p>
+          </Typography>
+          <Typography>
             <strong>Received:</strong> {selectedEmail?.receivedDateTime}
-          </p>
-          <div>
+          </Typography>
+          <Box>
             <strong>Body:</strong>
             <div
               dangerouslySetInnerHTML={{ __html: selectedEmail?.bodyPreview }}
             />
-          </div>
-        </Modal.Body>
-        <Modal.Footer>
-          <Button type="button" variant="secondary" onClick={handleCloseModal}>
+          </Box>
+          <Button type="button" variant="contained" color="secondary" onClick={handleCloseModal}>
             Close
           </Button>
-        </Modal.Footer>
+        </Box>
       </Modal>
     </Container>
   );

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useMsal } from "@azure/msal-react";
 import { useNavigate } from "react-router-dom";
+import { Container, Typography, Button, Box } from "@mui/material";
 
 /**
  * Home component
@@ -27,27 +28,21 @@ const Home: React.FC = () => {
   };
 
   return (
-    <div className="container auth-btn-container">
-      <h1 className="app-title">Email Engine Core</h1>
+    <Container className="auth-btn-container">
+      <Typography variant="h1" className="app-title">Email Engine Core</Typography>
       {isAuthenticated ? (
-        <>
-          <div className="text-center">
-            <p>Welcome: {accounts[0].username}</p>
-          </div>
-          <div className="text-center">
-            <button onClick={handleEmailSync} className="btn btn-primary">
-              Sync Email
-            </button>
-          </div>
-        </>
+        <Box textAlign="center">
+          <Typography>Welcome: {accounts[0].username}</Typography>
+          <Button onClick={handleEmailSync} variant="contained" color="primary">
+            Sync Email
+          </Button>
+        </Box>
       ) : (
-        <>
-          <button onClick={handleLogin} className="btn btn-primary">
-            Login with Outlook
-          </button>
-        </>
+        <Button onClick={handleLogin} variant="contained" color="primary">
+          Login with Outlook
+        </Button>
       )}
-    </div>
+    </Container>
   );
 };
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,8 +1,6 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Roboto', 'Helvetica', 'Arial', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
Update the front-end design to use Material-UI components and styles.

* **App.tsx**: Replace Bootstrap components with Material-UI components such as `Container`, `Grid`, and `Box`.
* **AddAccount.tsx**: Replace Bootstrap components with Material-UI components such as `Container`, `Typography`, and `CircularProgress`.
* **EmailPage.tsx**: Replace Bootstrap components with Material-UI components such as `Box`, `Typography`, `CircularProgress`, `TableContainer`, `Table`, `TableHead`, `TableRow`, `TableCell`, `TableBody`, `Paper`, `Tooltip`, and `IconButton`.
* **Home.tsx**: Replace Bootstrap components with Material-UI components such as `Container`, `Typography`, `Button`, and `Box`.
* **App.css**: Add Material-UI specific styles for `MuiContainer-root`, `MuiTypography-root`, `MuiButton-root`, `MuiBox-root`, and `MuiCircularProgress-root`.
* **index.css**: Update font-family to use Material-UI's default fonts.

